### PR TITLE
Use existing ontology URI to allow reusage

### DIFF
--- a/SafetyOntology.owl
+++ b/SafetyOntology.owl
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <Ontology xmlns="http://www.w3.org/2002/07/owl#"
-     xml:base="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl#"
+     xml:base="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     ontologyIRI="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl#">
+     ontologyIRI="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl">
     <Prefix name="" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>

--- a/SafetyOntology.owl
+++ b/SafetyOntology.owl
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <Ontology xmlns="http://www.w3.org/2002/07/owl#"
-     xml:base="http://www.semanticweb.org/mahsateimourikia/ontologies/2016/1/untitled-ontology-3"
+     xml:base="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     ontologyIRI="http://www.semanticweb.org/mahsateimourikia/ontologies/2016/1/untitled-ontology-3">
+     ontologyIRI="https://raw.githubusercontent.com/mahsa-teimourikia/Safety-Ontology/master/SafetyOntology.owl#">
     <Prefix name="" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>


### PR DESCRIPTION
Your current ontology URI `http://www.semanticweb.org/mahsateimourikia/ontologies/2016/1/untitled-ontology-3` leads to a 404 error. My approach is a minimal change, just use the URL to the raw file version of `SafetyOntology.owl`. It allows reusage and referencing the ontology.